### PR TITLE
[NO-TICKET] feat: bump RDS MySQL minor version

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -62,7 +62,7 @@ resource "aws_rds_cluster" "backend_store" {
   cluster_identifier_prefix = var.unique_name
   tags                      = local.tags
   engine                    = "aurora-mysql"
-  engine_version            = "5.7.mysql_aurora.2.07.1"
+  engine_version            = "5.7.mysql_aurora.2.08.3"
   engine_mode               = "serverless"
   port                      = local.db_port
   db_subnet_group_name      = aws_db_subnet_group.rds.name


### PR DESCRIPTION
Currently, there's only one place where this module is in use ([here](https://glovo.sourcegraph.com/search?q=context%3Aglobal+%22app.terraform.io%2Fglovo%2Fmlflow%2Faws%22+&patternType=standard&sm=1&groupBy=repo)) and the TF applies are [failing](https://app.terraform.io/app/glovo/workspaces/ml-platform-prod/runs/run-QXEFg4UevpN1sShA) because the RDS version doesn't match the one in the module.

This PR aims to make the MySQL versions match to fix Terraform state.